### PR TITLE
Fix message response attribution

### DIFF
--- a/client/app/components/DashboardPanel.js
+++ b/client/app/components/DashboardPanel.js
@@ -47,17 +47,18 @@ function compareByTimestamp(a, b) {
 }
 
 function curateMessageData(messagesSent,messagesReceived) {
-    let j = messagesReceived.length-1;
+    let j = 0;
     return messagesSent.map((item,i) => {
         item.responsesStart = j;
         let responses = 0;
-        while (j >= 0 && messagesReceived[j].time > item.time) {
+        while (j < messagesReceived.length && messagesReceived[j].time > item.time) {
             responses++;
-            j--;
+            j++;
         }
         return {
             to: item.toPhoneNumber,
             time: item.time,
+            message: item.message,
             responses: responses
         }
     });
@@ -72,6 +73,7 @@ const DashboardPanel = () => {
     const columns = React.useMemo(() => [
         { Header: 'To', accessor: 'to', },
         { Header: 'Time', accessor: 'time', },
+        { Header: 'Message', accessor: 'message', },
         { Header: 'Responses', accessor: 'responses', }],[]);
     const data = React.useMemo(() => curateMessageData(messagesSent,messagesReceived),
         [messagesSent,messagesReceived]);

--- a/server/app/server.js
+++ b/server/app/server.js
@@ -39,9 +39,8 @@ const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TO
 app.locals.jobSystem = new RecurringJobSystem(client);
 
 app.post('/sms-response', function(req, res, next) {
-    console.log(req.body);
     const originalMessage = Message.find({ toPhoneNumber: req.body.From })
-        .sort('-date').exec(function(err,docs) {
+        .sort('-time').exec(function(err,docs) {
             if (err) { console.error(err); } 
             else if (docs.length == 0) { console.error(`No messages sent to ${req.body.From}`); }
             else { 
@@ -51,7 +50,8 @@ app.post('/sms-response', function(req, res, next) {
                     message: req.body.Body
                 });
                 response.save()
-                    .then(()=> { console.log(`Saved ${response._id}.`); })
+                    .then(()=> { 
+                        console.log(`Saved ${response.message} as response to ${docs[0].message}.`); })
                     .catch((err)=>{ console.error(err); });
             }
         });
@@ -102,7 +102,7 @@ function sanitizeMessage(message) {
 
 // TODO: Add query parameter here to look for a specific to number
 app.get('/messages-sent', function(req, res, next) {
-    Message.find({}, function(err, result) {
+    Message.find({}).sort('-time').exec(function(err, result) {
         if(err) {
             return res.send(err);
         } else {
@@ -115,7 +115,7 @@ app.get('/messages-sent', function(req, res, next) {
 // TODO: Add query parameter here to look for a specific (from?) number
 // TODO: Create a 'sanitizeMessage' for the responses
 app.get('/messages-received', function(req, res, next) {
-    MessageResponse.find({}, function(err,result) {
+    MessageResponse.find({}).sort('-time').exec(function(err,result) {
         if (err) {
             return res.send(err);
         } else {


### PR DESCRIPTION
Fixes #65
The sort on the sms-response was based on an attribute that didn't exist
so it wasn't doing anything. It has been fixed, and the same sorting
has been added to both messages-sent and messages-received endpoints
so they are sorted from newest to oldest message. Message response
attribution is now correct and the dashboard correctly calculates
the number of responses.
